### PR TITLE
Changing paths to processing_provider and its modules to let Python in QGIS to read them.

### DIFF
--- a/processing_provider/provider.py
+++ b/processing_provider/provider.py
@@ -1,18 +1,18 @@
 from qgis.core import QgsProcessingProvider
 
-from processing_provider.rvt_hillshade import RVTHillshade
-from processing_provider.rvt_multi_hillshade import RVTMultiHillshade
-from processing_provider.rvt_slope import RVTSlope
-from processing_provider.rvt_slrm import RVTSlrm
-from processing_provider.rvt_svf import RVTSvf
-from processing_provider.rvt_asvf import RVTASvf
-from processing_provider.rvt_opns import RVTOpns
-from processing_provider.rvt_sky_illum import RVTSim
-from processing_provider.rvt_local_dom import RVTLocalDom
-from processing_provider.rvt_blender import RVTBlender
-from processing_provider.rvt_msrm import RVTMsrm
-from processing_provider.rvt_mstp import RVTMstp
-from processing_provider.rvt_fill_no_data import RVTFillNoData, RVTFillNoDataIDW
+from .rvt_hillshade import RVTHillshade
+from .rvt_multi_hillshade import RVTMultiHillshade
+from .rvt_slope import RVTSlope
+from .rvt_slrm import RVTSlrm
+from .rvt_svf import RVTSvf
+from .rvt_asvf import RVTASvf
+from .rvt_opns import RVTOpns
+from .rvt_sky_illum import RVTSim
+from .rvt_local_dom import RVTLocalDom
+from .rvt_blender import RVTBlender
+from .rvt_msrm import RVTMsrm
+from .rvt_mstp import RVTMstp
+from .rvt_fill_no_data import RVTFillNoData, RVTFillNoDataIDW
 
 
 class Provider(QgsProcessingProvider):

--- a/qrvt.py
+++ b/qrvt.py
@@ -67,7 +67,7 @@ import rvt.blend_func
 importlib.reload(rvt.blend_func)
 import rvt.vis
 importlib.reload(rvt.vis)
-from processing_provider.provider import Provider
+from .processing_provider.provider import Provider
 
 
 class LoadingScreenDlg:


### PR DESCRIPTION
Paths to local library "processing_provider" wasn't well defined (lack of "." [dot]), so Python wasn't capable to read it. The same rule in main provider.py module.
Since now QGIS 3.24 and 3.26 can use "rvt-qgis"