### PR TITLE
Fix scipy deprecation warning

### DIFF
--- a/rvt/vis.py
+++ b/rvt/vis.py
@@ -21,7 +21,7 @@ Copyright:
 # python libraries
 import numpy as np
 from scipy.interpolate import griddata, RectBivariateSpline
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 from scipy.spatial import cKDTree
 
 


### PR DESCRIPTION
While starting QGIS I get a new warning:
> warning:C:\Users/mtoews/AppData/Roaming/QGIS/QGIS4\profiles\default/python/plugins\rvt-qgis\rvt\vis.py:24: DeprecationWarning: Please import `distance_transform_edt` from the `scipy.ndimage` namespace; the `scipy.ndimage.morphology` namespace is deprecated and will be removed in SciPy 2.0.0.
              from scipy.ndimage.morphology import distance_transform_edt

This PR fixes the import from the correct module.

Xref upstream fix: https://github.com/EarthObservation/RVT_py/pull/40